### PR TITLE
unsafe-reset-all is under tendermint subcomand

### DIFF
--- a/statesync_DEVNET_client_linux_existing.sh
+++ b/statesync_DEVNET_client_linux_existing.sh
@@ -102,7 +102,8 @@ then
 
   sed -E -i -s 's/minimum-gas-prices = \".*\"/minimum-gas-prices = \"0.001ubcna\"/' $HOME/.bcna/config/app.toml
 
-  ./bcnad unsafe-reset-all
+  ./bcnad tendermint unsafe-reset-all --home $HOME/.bcna
+
   echo ##################################################################
   echo  "PLEASE HIT CTRL+C WHEN THE CHAIN IS SYNCED, Wait the last block"
   echo ##################################################################

--- a/statesync_DEVNET_client_linux_existing.sh
+++ b/statesync_DEVNET_client_linux_existing.sh
@@ -103,7 +103,6 @@ then
   sed -E -i -s 's/minimum-gas-prices = \".*\"/minimum-gas-prices = \"0.001ubcna\"/' $HOME/.bcna/config/app.toml
 
   ./bcnad tendermint unsafe-reset-all --home $HOME/.bcna
-
   echo ##################################################################
   echo  "PLEASE HIT CTRL+C WHEN THE CHAIN IS SYNCED, Wait the last block"
   echo ##################################################################


### PR DESCRIPTION
`./bcnad tendermint unsafe-reset-all --home $HOME/.bcna`

Including  `--home` because a bug in `v.0.34.19`